### PR TITLE
Fix compilation on Ubuntu 22

### DIFF
--- a/tests/anvill_passes/src/SinkSelectionsIntoBranchTargets.cpp
+++ b/tests/anvill_passes/src/SinkSelectionsIntoBranchTargets.cpp
@@ -12,6 +12,7 @@
 #include <doctest/doctest.h>
 #include <llvm/IR/Verifier.h>
 #include "Utils.h"
+#include <ostream>
 
 namespace anvill {
 


### PR DESCRIPTION
Error I got:

```
In file included from /root/anvill/tests/anvill_passes/src/SinkSelectionsIntoBranchTargets.cpp:9:
In file included from /root/anvill/include/anvill/Passes/SinkSelectionsIntoBranchTargets.h:11:
In file included from /root/cxx-common/vcpkg/installed/x64-linux-rel/include/llvm/IR/PassManager.h:40:
In file included from /root/cxx-common/vcpkg/installed/x64-linux-rel/include/llvm/ADT/DenseMap.h:17:
In file included from /root/cxx-common/vcpkg/installed/x64-linux-rel/include/llvm/ADT/DenseMapInfo.h:20:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/tuple:38:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/utility:70:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_pair.h:59:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/move.h:57:
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/type_traits:1422:66: error: implicit instantiation of undefined template 'std::basic_ostream<char>'
    : public integral_constant<bool, __is_base_of(_Base, _Derived)>
                                                                 ^
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/llvm/IR/DiagnosticInfo.h:545:21: note: in instantiation of template class 'std::is_base_of<llvm::DiagnosticInfoOptimizationBase, std::basic_ostream<char>>' requested here
               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
                    ^
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/doctest/doctest.h:1004:43: note: while substituting deduced template arguments into function template 'operator<<' [with RemarkT = std::basic_ostream<char>]
struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
                                          ^
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/doctest/doctest.h:1053:13: note: during template argument deduction for class template partial specialization 'has_insertion_operator<T, decltype(operator<<(declval<std::ostream &>(), declval<const T &>()) , void())>' [with T = llvm::Module *]
    detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value || detail::types::is_array<T>::value>
            ^
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/doctest/doctest.h:1053:13: note: in instantiation of template class 'doctest::detail::has_insertion_operator<llvm::Module *>' requested here
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/doctest/doctest.h:1079:12: note: in instantiation of template class 'doctest::StringMaker<llvm::Module *>' requested here
    return StringMaker<T>::convert(value);
           ^
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/doctest/doctest.h:1318:17: note: in instantiation of function template specialization 'doctest::toString<llvm::Module *, true>' requested here
        return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
                ^
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/doctest/doctest.h:1060:32: note: expanded from macro 'DOCTEST_STRINGIFY'
#define DOCTEST_STRINGIFY(...) toString(__VA_ARGS__)
                               ^
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/doctest/doctest.h:1486:9: note: in instantiation of function template specialization 'doctest::detail::stringifyBinaryExpr<llvm::Module *, std::nullptr_t>' requested here
        DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(!=, " != ", DOCTEST_CMP_NE) //!OCLINT bitwise operator in conditional
        ^
/root/cxx-common/vcpkg/installed/x64-linux-rel/include/doctest/doctest.h:1338:32: note: expanded from macro 'DOCTEST_DO_BINARY_EXPRESSION_COMPARISON'
            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                             \
                               ^
/root/anvill/tests/anvill_passes/src/SinkSelectionsIntoBranchTargets.cpp:25:26: note: in instantiation of function template specialization 'doctest::detail::Expression_lhs<llvm::Module *>::operator!=<std::nullptr_t>' requested here
    REQUIRE(module.get() != nullptr);
                         ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/iosfwd:86:11: note: template is declared here
    class basic_ostream;
          ^
1 error generated.
[7/8] Linking CXX executable bin/Decompile/anvill-decompile-json
ninja: build stopped: subcommand failed.
cmake --build anvill_build -j 16  21.04s user 2.65s system 188% cpu 12.587 total

```